### PR TITLE
update for zstandard compression

### DIFF
--- a/blendercreator.cpp
+++ b/blendercreator.cpp
@@ -35,18 +35,18 @@ bool BlendCreator::create(const QString& path, int width , int height, QImage& i
     qCDebug(LOG_KIO_BLEND) << "blend.open" << path << endl;
     return false;
   }
-  KCompressionDevice * gz_file;
+  KCompressionDevice * z_file;
   QDataStream in_data;
   char zipmagick[2];
   qint64 z = in_file.peek(zipmagick,2);
   
     unsigned char zm2 = zipmagick[1];
     unsigned char zm1 = zipmagick[0];
-  if(z && zm1==0x1f && zm2 == 0x8b) {
+  if(z && zm1==0xfd && zm2 == 0x28) {
     in_file.close();
-    gz_file = new KCompressionDevice(path, KCompressionDevice::GZip);
-    gz_file->open(QIODevice::ReadOnly);
-    in_data.setDevice(gz_file);
+    z_file = new KCompressionDevice(path, KCompressionDevice::Zstd);
+    z_file->open(QIODevice::ReadOnly);
+    in_data.setDevice(z_file);
   } else {
     in_data.setDevice(&in_file);
   }


### PR DESCRIPTION
Hello @kayosiii 
Can you check my patch?
It's works, but not for all thumb sizes
https://user-images.githubusercontent.com/3109995/166575318-a7e2f508-c3f8-4063-ae14-b828f190a79a.mp4

And, please check bytes, i add only 2, but looks like its 4
https://stackoverflow.com/questions/68637971/how-to-detect-zstd-compression

this is script for upstream version 
[zstandard-22.04.0.txt](https://github.com/kayosiii/kde-thumbnailer-blender/files/8614579/zstandard-22.04.0.txt)
 